### PR TITLE
Welcome to the new cstring() realdom

### DIFF
--- a/Cstring.php
+++ b/Cstring.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2014, Ivan Enderlin. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace {
+
+from('Hoa')
+
+/**
+ * \Hoa\Realdom
+ */
+-> import('Realdom.~')
+
+/**
+ * \Hoa\String
+ */
+-> import('String.~');
+
+}
+
+namespace Hoa\Realdom {
+
+/**
+ * Class \Hoa\Realdom\Cstring.
+ *
+ * Realistic domain: cstring.
+ *
+ * @author     Ivan Enderlin <ivan.enderlin@hoa-project.net>
+ * @copyright  Copyright © 2007-2014 Ivan Enderlin.
+ * @license    New BSD License
+ */
+
+class Cstring extends Realdom {
+
+    /**
+     * Realistic domain name.
+     *
+     * @const string
+     */
+    const NAME = 'cstring';
+
+    /**
+     * Realistic domain defined arguments.
+     *
+     * @var \Hoa\Realdom array
+     */
+    protected $_arguments = array(
+        'Integer length' => -1
+    );
+
+
+
+    /**
+     * Predicate whether the sampled value belongs to the realistic domains.
+     *
+     * @access  protected
+     * @param   mixed  $q    Sampled value.
+     * @return  boolean
+     */
+    protected function _predicate ( $q ) {
+
+        if(!is_string($q))
+            return false;
+
+        $length = $this['length'];
+
+        if(   $length instanceof IRealdom\Constant
+           && -1 === $length->getConstantValue())
+            return true;
+
+        return $length->predicate(strlen($q));
+    }
+
+    /**
+     * Sample one new value.
+     *
+     * @access  protected
+     * @param   \Hoa\Math\Sampler  $sampler    Sampler.
+     * @return  mixed
+     */
+    protected function _sample ( \Hoa\Math\Sampler $sampler ) {
+
+        $string = null;
+        $min    = 32;
+        $max    = 126;
+        $length = $this['length']->sample($sampler);
+
+        if(0 >= $length)
+            $length = $sampler->getInteger(0, 7);
+
+        for($i = 0; $i < $length; ++$i)
+            $string .= \Hoa\String::fromCode($sampler->getInteger(
+                $min,
+                $max
+            ));
+
+        return $string;
+    }
+}
+
+}


### PR DESCRIPTION
Hello :-),

This is an alternative to the `string` and `regex` realdoms. This one considers a string as a list of characters (so, no unicode here) and has only one argument: `length`. If not set, the length is not considered. This is useful to express generic PHP strings (like free ID for example).

Thoughts?
