### PR TITLE
Fix conflicts with PHP7

### DIFF
--- a/Boundfloat.php
+++ b/Boundfloat.php
@@ -46,7 +46,7 @@ use Hoa\Math;
  * @copyright  Copyright © 2007-2015 Hoa community
  * @license    New BSD License
  */
-class Boundfloat extends Float implements IRealdom\Interval
+class Boundfloat extends RealdomFloat implements IRealdom\Interval
 {
     /**
      * Realistic domain name.

--- a/Color.php
+++ b/Color.php
@@ -46,7 +46,7 @@ use Hoa\Math;
  * @copyright  Copyright © 2007-2015 Hoa community
  * @license    New BSD License
  */
-class Color extends String
+class Color extends RealdomString
 {
     /**
      * Realistic domain name.

--- a/Constfloat.php
+++ b/Constfloat.php
@@ -46,7 +46,7 @@ use Hoa\Math;
  * @copyright  Copyright © 2007-2015 Hoa community
  * @license    New BSD License
  */
-class Constfloat extends Float implements IRealdom\Constant
+class Constfloat extends RealdomFloat implements IRealdom\Constant
 {
     /**
      * Realistic domain name.

--- a/Conststring.php
+++ b/Conststring.php
@@ -46,7 +46,7 @@ use Hoa\Math;
  * @copyright  Copyright © 2007-2015 Hoa community
  * @license    New BSD License
  */
-class Conststring extends String implements IRealdom\Constant
+class Conststring extends RealdomString implements IRealdom\Constant
 {
     /**
      * Realistic domain name.

--- a/Crate/Constant.php
+++ b/Crate/Constant.php
@@ -143,7 +143,7 @@ class          Constant
                 $out[] = $prefix . 'Constfloat';
             } elseif ($realdom instanceof Realdom\Integer) {
                 $out[] = $prefix . 'Constinteger';
-            } elseif ($realdom instanceof Realdom\String) {
+            } elseif ($realdom instanceof Realdom\RealdomString) {
                 $out[] = $prefix . 'Conststring';
             } else {
                 throw new Realdom\Exception(

--- a/Crate/Constant.php
+++ b/Crate/Constant.php
@@ -139,7 +139,7 @@ class          Constant
                 $out[] = $prefix . 'Constarray';
             } elseif ($realdom instanceof Realdom\Boolean) {
                 $out[] = $prefix . 'Constboolean';
-            } elseif ($realdom instanceof Realdom\Float) {
+            } elseif ($realdom instanceof Realdom\RealdomFloat) {
                 $out[] = $prefix . 'Constfloat';
             } elseif ($realdom instanceof Realdom\Integer) {
                 $out[] = $prefix . 'Constinteger';

--- a/Date.php
+++ b/Date.php
@@ -39,7 +39,7 @@ namespace Hoa\Realdom;
 use Hoa\Math;
 
 /**
- * Class \Hoa\Realdom\String.
+ * Class \Hoa\Realdom\Date.
  *
  * Realistic domain: date.
  *
@@ -69,8 +69,8 @@ class Date extends Realdom
      * @var array
      */
     protected $_arguments        = [
-        'String  format'    => 'c',
-        'Integer timestamp' => -1
+        'RealdomString  format'    => 'c',
+        'Integer        timestamp' => -1
     ];
 
 

--- a/Grammar.php
+++ b/Grammar.php
@@ -49,7 +49,7 @@ use Hoa\Regex;
  * @copyright  Copyright © 2007-2015 Hoa community
  * @license    New BSD License
  */
-class Grammar extends String
+class Grammar extends RealdomString
 {
     /**
      * Realistic domain name.

--- a/RealdomFloat.php
+++ b/RealdomFloat.php
@@ -39,14 +39,14 @@ namespace Hoa\Realdom;
 use Hoa\Math;
 
 /**
- * Class \Hoa\Realdom\Float.
+ * Class \Hoa\Realdom\RealdomFloat.
  *
  * Realistic domain: float.
  *
  * @copyright  Copyright © 2007-2015 Hoa community
  * @license    New BSD License
  */
-class Float extends Realdom implements Number
+class RealdomFloat extends Realdom implements Number
 {
     /**
      * Realistic domain name.

--- a/RealdomObject.php
+++ b/RealdomObject.php
@@ -39,14 +39,14 @@ namespace Hoa\Realdom;
 use Hoa\Math;
 
 /**
- * Class \Hoa\Realdom\Object.
+ * Class \Hoa\Realdom\RealdomObject.
  *
  * Realistic domain: object.
  *
  * @copyright  Copyright © 2007-2015 Hoa community
  * @license    New BSD License
  */
-class Object extends Realdom
+class RealdomObject extends Realdom
 {
     /**
      * Realistic domain name.

--- a/RealdomString.php
+++ b/RealdomString.php
@@ -37,17 +37,17 @@
 namespace Hoa\Realdom;
 
 use Hoa\Math;
-use Hoa\String as HoaString;
+use Hoa\String;
 
 /**
- * Class \Hoa\Realdom\String.
+ * Class \Hoa\Realdom\RealdomString.
  *
  * Realistic domain: string.
  *
  * @copyright  Copyright © 2007-2015 Hoa community
  * @license    New BSD License
  */
-class          String
+class          RealdomString
     extends    Realdom
     implements IRealdom\Nonconvex,
                IRealdom\Finite
@@ -88,12 +88,12 @@ class          String
     {
         if ($this['codepointMin'] instanceof Conststring) {
             $char                 = mb_substr($this['codepointMin']->getConstantValue(), 0, 1);
-            $this['codepointMin'] = new Constinteger(HoaString::toCode($char));
+            $this['codepointMin'] = new Constinteger(String::toCode($char));
         }
 
         if ($this['codepointMax'] instanceof Conststring) {
             $char                 = mb_substr($this['codepointMax']->getConstantValue(), 0, 1);
-            $this['codepointMax'] = new Constinteger(HoaString::toCode($char));
+            $this['codepointMax'] = new Constinteger(String::toCode($char));
         }
 
         return;
@@ -128,7 +128,7 @@ class          String
         $max    = $this['codepointMax']->getConstantValue();
 
         foreach ($split as $letter) {
-            $handle = HoaString::toCode($letter);
+            $handle = String::toCode($letter);
             $out    = $out && ($min <= $handle) && ($handle <= $max);
         }
 
@@ -153,7 +153,7 @@ class          String
         }
 
         for ($i = 0; $i < $length; ++$i) {
-            $string .= HoaString::fromCode($sampler->getInteger(
+            $string .= String::fromCode($sampler->getInteger(
                 $min,
                 $max,
                 $this->_discredited
@@ -171,7 +171,7 @@ class          String
      */
     public function discredit($value)
     {
-        $_value = HoaString::toCode($value);
+        $_value = String::toCode($value);
 
         if (true  === in_array($_value, $this->_discredited) ||
             false === $this->predicate($value)) {

--- a/RealdomString.php
+++ b/RealdomString.php
@@ -37,7 +37,7 @@
 namespace Hoa\Realdom;
 
 use Hoa\Math;
-use Hoa\String;
+use Hoa\Ustring;
 
 /**
  * Class \Hoa\Realdom\RealdomString.
@@ -88,12 +88,12 @@ class          RealdomString
     {
         if ($this['codepointMin'] instanceof Conststring) {
             $char                 = mb_substr($this['codepointMin']->getConstantValue(), 0, 1);
-            $this['codepointMin'] = new Constinteger(String::toCode($char));
+            $this['codepointMin'] = new Constinteger(Ustring::toCode($char));
         }
 
         if ($this['codepointMax'] instanceof Conststring) {
             $char                 = mb_substr($this['codepointMax']->getConstantValue(), 0, 1);
-            $this['codepointMax'] = new Constinteger(String::toCode($char));
+            $this['codepointMax'] = new Constinteger(Ustring::toCode($char));
         }
 
         return;
@@ -128,7 +128,7 @@ class          RealdomString
         $max    = $this['codepointMax']->getConstantValue();
 
         foreach ($split as $letter) {
-            $handle = String::toCode($letter);
+            $handle = Ustring::toCode($letter);
             $out    = $out && ($min <= $handle) && ($handle <= $max);
         }
 
@@ -153,7 +153,7 @@ class          RealdomString
         }
 
         for ($i = 0; $i < $length; ++$i) {
-            $string .= String::fromCode($sampler->getInteger(
+            $string .= Ustring::fromCode($sampler->getInteger(
                 $min,
                 $max,
                 $this->_discredited
@@ -171,7 +171,7 @@ class          RealdomString
      */
     public function discredit($value)
     {
-        $_value = String::toCode($value);
+        $_value = Ustring::toCode($value);
 
         if (true  === in_array($_value, $this->_discredited) ||
             false === $this->predicate($value)) {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "hoa/math"    : "~0.0",
         "hoa/praspel" : "~0.0",
         "hoa/regex"   : "~0.0",
-        "hoa/string"  : "~2.0",
+        "hoa/ustring" : "~3.0",
         "hoa/visitor" : "~1.0"
     },
     "autoload": {


### PR DESCRIPTION
Related to hoaproject/Core#80.
:warning: MUST BE MERGED AFTER hoaproject/Core#82 is closed! :warning:

# `Object` might create a conflict with PHP7.x

Fix #12.

Quoting https://github.com/php/php-src/blob/7dcfdbbee4/UPGRADING#L392-L398:

>  Furthermore the following class, interface and trait names are now reserved
>  for future use, but do not yet throw an error when used:
>    * resource
>    * object
>    * mixed
>    * numeric

# `Float` and `String` will create a conflict with PHP7.x

Fix #11.

Quoting https://github.com/php/php-src/blob/7dcfdbbee4/UPGRADING#L378-L387:

> It is no longer possible to use the following class, interface and trait names
> (case-insensitive):
>
>   * bool
>   * int
>   * float
>   * string
>   * null
>   * false
>   * true