### PR TITLE
Replace void by null as void is now a reserved keyword

### DIFF
--- a/RealdomEmpty.php
+++ b/RealdomEmpty.php
@@ -76,6 +76,6 @@ class RealdomEmpty extends Realdom
      */
     protected function _sample(Math\Sampler $sampler)
     {
-        return void;
+        return null;
     }
 }


### PR DESCRIPTION
`void` for PHP-7.1 is now a reserved keyword[1]. This patch replace the
return void by return null;

[1] https://github.com/php/php-src/blob/php-7.1.0alpha2/UPGRADING